### PR TITLE
add redirect functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,10 +12,17 @@ loop = asyncio.get_event_loop()
 BOT_PREFIX = ">"
 bot = commands.Bot(command_prefix=BOT_PREFIX, case_insensitive=True)
 
+
 with open("bot_token.txt", "r+") as f:
 	token = [i.strip() for i in f.readlines()][0]
 with open("counter.txt", "r+") as f:
     counter = [i.strip() for i in f.readlines()][0]
+with open("options.txt", "r+") as f:
+    redirectbool = [i.strip() for i in f.readlines()][0]
+with open("redirect_channel.txt", "r+") as f:
+    redirectchannel = [i.strip() for i in f.readlines()][0]
+
+channel = bot.get_channel(int(redirectchannel))
 
 
 @tasks.loop(seconds = 30)
@@ -31,9 +38,15 @@ async def update():
 
 @bot.event
 async def on_ready():
+    print('------')
     print('Logged in as')
     print(bot.user.name)
     print(bot.user.id)
+    print(redirectbool)
+    print(redirectchannel)
+    global channel
+    channel = bot.get_channel(int(redirectchannel))
+    print(channel)
     print('------')
     sleep(5)
     update.start()
@@ -42,14 +55,24 @@ async def on_ready():
 async def on_message(message):
     global intcounter
     global addtocounter
+    global channel
     embeds = message.embeds
-    channel = bot.get_channel("930189197720047637")
     for embed in embeds:
         if "Rancher's Boots" in embed.description:
             if "#000000" in embed.fields[2].value:
                 await message.delete()
                 addtocounter += 1
                 return
+        elif redirectbool == "redirect=TRUE":
+            if message.author == bot.user:
+                return
+            else:
+                redirectembed = discord.Embed(title=embed.title, description=embed.description, color=embed.color)
+                redirectembed.add_field(name=embed.fields[0].name, value=embed.fields[0].value)
+                redirectembed.add_field(name=embed.fields[1].name, value=embed.fields[1].value)
+                redirectembed.add_field(name=embed.fields[2].name, value=embed.fields[2].value)
+                redirectembed.set_footer(text="Tropical Cleanup Redirect")
+                await channel.send(embed=redirectembed)
             
 def exithandler():
     with open("counter.txt", "w+") as f:

--- a/options.txt
+++ b/options.txt
@@ -1,0 +1,1 @@
+redirect=FALSE

--- a/redirect_channel.txt
+++ b/redirect_channel.txt
@@ -1,0 +1,1 @@
+put your channel ID here!


### PR DESCRIPTION
Adds the ability to redirect the incoming embeds from one channel to another to prevent hearing ping noises for deleted embeds. Simply mute the channel that the webhooks are sending to and leave the channel you want to hear unmuted.